### PR TITLE
Fix broken docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TruStacks uses a rule engine to generate actions plans that contain actions base
 
 ## Docs
 
-View the docs [here](docs.trustacks.io)
+View the docs at [docs.trustacks.io](https://docs.trustacks.io).
 
 ### Contributing
 


### PR DESCRIPTION
- fix docs link: it lacked the protocol.
- use the domain as link text, so it is preserved when copy-pasted.